### PR TITLE
Fixes an error in the scenario example

### DIFF
--- a/rancher/rancher-ui/applications/stacks/adding-service-alias/index.md
+++ b/rancher/rancher-ui/applications/stacks/adding-service-alias/index.md
@@ -6,7 +6,7 @@ layout: rancher-default
 ## Adding Service Alias
 ---
 
-By adding a service alias, it provides easier flexibility when upgrading services. In our example, we could have an application, which is version 1. We'll name the service `AppV1`. We can create a service alias named `AppName` and link it to the `AppV1` service. If you have an updated application, you can create a `AppV2` service and add it to `AppName`. When you have completed all your testing of `AppV2`, you can then stop and eventually delete the `AppV2` service. Since the service alias is in place, there is no disruption to your application and you have easily upgraded your service without having to re-configure anything linking to the `AppName` service!
+By adding a service alias, it provides easier flexibility when upgrading services. In our example, we could have an application, which is version 1. We'll name the service `AppV1`. We can create a service alias named `AppName` and link it to the `AppV1` service. If you have an updated application, you can create a `AppV2` service and add it to `AppName`. When you have completed all your testing of `AppV2`, you can then stop and eventually delete the `AppV1` service. Since the service alias is in place, there is no disruption to your application and you have easily upgraded your service without having to re-configure anything linking to the `AppName` service!
 
 Inside your stack, you add a service alias by clicking on the dropdown icon next to the **Add Service** button. Select **Service Alias**. Alternatively, if you are viewing the stacks at the stack level, the same **Add Service** dropdown is visible for each specific stack.
 

--- a/rancher/rancher-ui/applications/stacks/index.md
+++ b/rancher/rancher-ui/applications/stacks/index.md
@@ -66,7 +66,7 @@ For services and load balancers, you can quickly increase the number of containe
 You can also increase or decrease the number of containers in a service by selecting **Edit** on the dropdown menu for the service. The dropdown menu is visible when hovering over the service. Move the slider for **Scale** to change the number containers in the service.
 
 ### Editing 
-There are limited options for editing a service as Docker containers are immutable (not changeable) after creation. Rhe only things you can edit are things that we store that aren't really part of the Docker container. This includes restarting, it's still the same container if you stop and start it. You will need to remove and recreate a service to change anything else. An easy way to make changes to a service is to **Clone** the service. 
+There are limited options for editing a service as Docker containers are immutable (not changeable) after creation. The only things you can edit are things that we store that aren't really part of the Docker container. This includes restarting, it's still the same container if you stop and start it. You will need to remove and recreate a service to change anything else. An easy way to make changes to a service is to **Clone** the service. 
 
 To see what you can change, you select **Edit** on the dropdown menu of the service. The name, description and scale can be changed for all services. If you forgot to link your service when you had set it up, you will have the ability to link services through this option for any of our services (i.e. services, load balancers, service alias and external service).
 


### PR DESCRIPTION
The scenario had an error where it stated that AppV2 can be removed after testing and thus result in the service being upgraded. That's incorrect and should ready AppV1 otherwise, you haven't upgraded anything.