### PR TITLE
Adds an example to give more understanding to the reader.

### DIFF
--- a/rancher/rancher-ui/applications/stacks/adding-balancers/index.md
+++ b/rancher/rancher-ui/applications/stacks/adding-balancers/index.md
@@ -65,6 +65,16 @@ To add SSL termination to your load balancer, you can select the **SSL** checkbo
 
 To add a certificate to Rancher, please read about [how to add certificates in the **Infrastructure** tab]({{site.baseurl}}/rancher/rancher-ui/infrastructure/certificates/).
 
+For example, if you were load balancing a web server and wanted both `http` and `https` being served on ports 80 and 443 respectively, you would do the following:
+
+ 1. [Add a certificate to the infrastructure]({{site.baseurl}}/rancher/rancher-ui/infrastructure/certificates/).
+ 2. Create the load balancer service.
+ 3. In the *Listening Ports* section of the screen, create an entry to map the incoming port 80, with the `http` protocol and SSL _unchecked_.
+ 4. And then add another port mapping the incoming port 443, `http` protocol and SSL _checked_.
+ 5. In the *SSL Termination* section, select the certificate to use for the SSL port.
+
+It is possible to provide multiple certificates for the load balancer such that the appropriate certificate is presented to the client based on the hostname requested (see [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication)). This may not work with older clients which don't support SNI (those will get the main certificate). For modern clients, they will be offered the certificate from the list for which there is a match or the main certficiate if there is no match.
+
 ### Advanced Routing Options
 
 Rancher supports L7 load balancing with our advanced routing options. To expand the advanced options, click on the **Show advanced routing options**. The only required field is **Target Service**, which would be L4 load balancing. All of the other fields for L7 load balancing are optional. Since all the fields are optional, the listening ports are default when adding host/request paths, and the ports will be overriden if you specify source/target ports for a service. For each option, we cover some basic examples, but you can use all or some of these options together to define exactly how you want your load balancer to direct traffic to your services.


### PR DESCRIPTION
Added an example on the load balancer with SSL Termination based on what I understood after trying it out to make the text clearer.

Also added data on multiple certificates which wasn't covered.

Question - what's your "policy" regarding screenshots in the docs? I don't see any right now and I think it could make the text way easier to understand as some long winded sentences could simply refer to a picture below.