### PR TITLE
os/quick-start-guide: Fix code in example

### DIFF
--- a/os/quick-start-guide/index.md
+++ b/os/quick-start-guide/index.md
@@ -156,7 +156,7 @@ To make the container survive during the reboots, you should create the `/opt/ra
 
 ```bash
 $ sudo mkdir -p /opt/rancher/bin
-$ sudo echo “sudo system-docker start busydash” >> /opt/rancher/bin/start.sh
+$ echo “sudo system-docker start busydash” | sudo tee -a /opt/rancher/bin/start.sh
 $ sudo chmod 755 /opt/rancher/bin/start.sh
 ```
 


### PR DESCRIPTION
The code snippet at section "Deploying a system service container" of
<http://docs.rancher.com/os/quick-start-guide/> contains an error:

```
[rancher@rancher-01 ~]$ sudo echo "sudo system-docker start busydash" >>/opt/rancher/bin/start.sh
-bash: /opt/rancher/bin/start.sh: Permission denied
```

The correct command is the following:

```
[rancher@rancher-01 ~]$ echo "sudo system-docker start busydash" | sudo tee -a /opt/rancher/bin/start.sh
sudo system-docker start busydash
[rancher@rancher-01 ~]$
```

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>