### PR TITLE
Updates rancher-services/storage-services with  the host label convoy.glusterfs=true

### DIFF
--- a/rancher/rancher-services/storage-service/index.md
+++ b/rancher/rancher-services/storage-service/index.md
@@ -80,7 +80,7 @@ In this example, we're going to provide an example of how to use GlusterFS to ha
 <br>
 2. Add Labels to Hosts
    * While you are waiting for the Gluster FS service to become active, add the same label to hosts that you want to have shared storage. You can add labels to existing hosts by clicking on **Edit** in the dropdown of the host. 
-   * Add the desired label to the host. **Note:** By default, the Convoy Gluster service from the catalog will use the label `convoy.gluster=true`. Click on **Save**. 
+   * Add the desired label to the host. **Note:** By default, the Convoy Gluster service from the catalog will use the label `convoy.glusterfs=true`. Click on **Save**. 
 <br>
 3. Launch Convoy Gluster
    * In the **Applications** -> **Catalog**, click on **View Details** of the **Convoy Gluster** service.  


### PR DESCRIPTION
Currently the docs specify the label convoy.gluster = true, which doesn't work using the stack from the catalog.  This commit modifies the docs to use the default host label as per https://github.com/rancher/rancher-catalog/blob/master/templates/convoy-gluster/0/rancher-compose.yml.