### PR TITLE
Used :stable where appropriate, clarified quickstart instructions

### DIFF
--- a/rancher/latest/en/installing-rancher/installing-server/basic-ssl-config/index.md
+++ b/rancher/latest/en/installing-rancher/installing-server/basic-ssl-config/index.md
@@ -26,7 +26,7 @@ In our example configuration, all traffic will pass through the proxy and be sen
 Start Rancher server. We have added in `--name=rancher-server` to this command in order to link the proxy container to the Rancher server container.
 
 ```bash
-$ sudo docker run -d --restart=always --name=rancher-server rancher/server
+$ sudo docker run -d --restart=always --name=rancher-server rancher/server:stable
 ```
 <br>
 
@@ -166,7 +166,7 @@ Rancher Compose CLI will require the CA certificate as part of the default store
 
 
    ```bash
-   $ sudo docker run -d --restart=always -p 8080:8080 -v /some/dir/cert.crt:/ca.crt rancher/server
+   $ sudo docker run -d --restart=always -p 8080:8080 -v /some/dir/cert.crt:/ca.crt rancher/server:stable
    ```
     <br>
 

--- a/rancher/latest/en/installing-rancher/installing-server/index.md
+++ b/rancher/latest/en/installing-rancher/installing-server/index.md
@@ -22,7 +22,7 @@ Rancher is deployed as a set of Docker containers. Running Rancher is a simple a
 On the Linux machine with Docker installed, the command to start Rancher is simple.
 
 ```bash
-$ sudo docker run -d --restart=always -p 8080:8080 rancher/server
+$ sudo docker run -d --restart=always -p 8080:8080 rancher/server:stable
 ```
 
 #### Rancher UI
@@ -43,7 +43,7 @@ Start Rancher by bind mounting the volume that has the certificate. The certific
 
 ```bash
 $ sudo docker run -d --restart=always -p 8080:8080 \
-  -v /dir_that_contains_the_cert/cert.crt:/ca.crt rancher/server
+  -v /dir_that_contains_the_cert/cert.crt:/ca.crt rancher/server:stable
 ```
 
 You can check that the `ca.crt` was passed to Rancher server container successfully by checking the logs of the rancher server container.
@@ -69,7 +69,7 @@ done.
 If you would like to persist the database inside your container to a volume on your host, launch Rancher server by bind mounting the MySQL volume.
 
 ```bash
-$ sudo docker run -d -v <host_vol>:/var/lib/mysql --restart=always -p 8080:8080 rancher/server
+$ sudo docker run -d -v <host_vol>:/var/lib/mysql --restart=always -p 8080:8080 rancher/server:stable
 ```
 With this command, the database will persist on the host. If you have an existing Rancher container and would like to bind mount the MySQL volume, the instructions are located in our [upgrading documentation]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/upgrading/#upgrading-rancher-launched-using-bind-mounts).
 
@@ -109,7 +109,7 @@ $ sudo docker run -d --restart=always -p 8080:8080 \
     -e CATTLE_DB_CATTLE_MYSQL_NAME=<Name of Database> \
     -e CATTLE_DB_CATTLE_USERNAME=<Username> \
     -e CATTLE_DB_CATTLE_PASSWORD=<Password> \
-    rancher/server
+    rancher/server:stable
 ```
 
 <a id="http-proxy"></a>
@@ -133,7 +133,7 @@ $ sudo docker run -d \
     -e http_proxy=<proxyURL> \
     -e https_proxy=<proxyURL> \
     -e no_proxy="localhost,127.0.0.1" \
-    --restart=always -p 8080:8080 rancher/server
+    --restart=always -p 8080:8080 rancher/server:stable
 ```
 
 If the [Rancher catalog]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/catalog/) will not be used, run the Rancher server command as you normally would.

--- a/rancher/latest/en/quick-start-guide/index.md
+++ b/rancher/latest/en/quick-start-guide/index.md
@@ -40,13 +40,13 @@ For simplicity, we will add the same host running the Rancher server as a host i
 
 To add a host, access the UI and click **Infrastructure**, which will immediately bring you to the **Hosts** page. Click on the **Add Host**. Rancher will prompt you to select an IP address. This IP address must be reachable from all the hosts that you will be adding. This is useful in installations where Rancher server will be exposed to the Internet through a NAT firewall or a load balancer. If your host has a private or local IP address like `192.168.*.*`, Rancher will print a warning asking you to make sure hosts can indeed reach the IP.
 
-For now you can ignore these warnings as we will only add the Rancher server host itself. Click **Save**. By default, you will be directed to the **Custom** option, which allows you to find the command that launches the rancher/agent container. There will also be options for cloud providers that use `docker-machine` to launch hosts. In the UI, Rancher will provide a command to use to add hosts.
+For now you can ignore these warnings as we will only add the Rancher server host itself. Click **Save**. By default, you will be directed to the **Custom** option, which allows you to find the command that launches the rancher/agent container. There will also be options for cloud providers that use `docker-machine` to launch hosts. In the UI, Rancher will provide a custom command to use to add hosts, an example of which is shown below.
 
 ```bash
 $ sudo docker run -d --privileged -v /var/run/docker.sock:/var/run/docker.sock rancher/agent:v0.7.9 http://172.17.0.3:8080/v1/scripts/DB121CFBA836F9493653:1434085200000:2ZOwUMd6fIzz44efikGhBP1veo
 ```
 
-Since we are adding a host that is also running Rancher server, we need to add the public IP that should be used for the host. Without this addition to the Rancher agent command, the IP will most likely be set incorrectly for the host. You can add this IP in **Step 4**, which will alter the command and add an environment variable.
+Since we are adding a host that is also running Rancher server, we need to add the public IP that should be used for the host. Without this addition to the Rancher agent command, the IP will most likely be set incorrectly for the host. You can add this IP in **Step 4**, which will alter the command and add an environment variable, example shown below.
 
 ```bash
 $ sudo docker run -e CATTLE_AGENT_IP=172.17.0.3 -d --privileged -v /var/run/docker.sock:/var/run/docker.sock rancher/agent:v0.7.9 http://172.17.0.3:8080/v1/scripts/DB121CFBA836F9493653:1434085200000:2ZOwUMd6fIzz44efikGhBP1veo


### PR DESCRIPTION
As highlighted in https://github.com/rancher/rancher/issues/4779 a users first experience of Rancher, should probably be of the stable build, not latest. Also took the opportunity to add some clarity to quick start guide, had someone take those command examples too literally recently!