### PR TITLE
change <environment_name> to <stack_name>

### DIFF
--- a/rancher/latest/en/rancher-services/internal-dns-service/index.md
+++ b/rancher/latest/en/rancher-services/internal-dns-service/index.md
@@ -136,7 +136,7 @@ PING bar.foo.stacka (10.42.x.x) 56(84) bytes of data.
 
 From any container, you can ping another container in the environment by their name regardless if they are in a different stack or service.
 
-In our example, we have a stack called `stackA`, which contains a service called `foo`. We also have another stack called `stackB`, which contains a service called `bar`. The names of containers are `<environment_name>_<service_name>_<number>`.
+In our example, we have a stack called `stackA`, which contains a service called `foo`. We also have another stack called `stackB`, which contains a service called `bar`. The names of containers are `<stack_name>_<service_name>_<number>`.
 
 If we exec into one of the containers in the `foo` service, you can ping the container in the `bar` service. 
 


### PR DESCRIPTION
It seems that the names of containers are `<stack_name>_<service_name>_<number>`