### PR TITLE
Link-ifying Configuration

### DIFF
--- a/rancher/latest/en/index.md
+++ b/rancher/latest/en/index.md
@@ -58,7 +58,7 @@ If you are ready to set up a production-grade Rancher installation, follow the i
 
 Before you start using Rancher, make sure to read through the [Concepts]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/concepts/) section to understand how Rancher works.
 
-The Configuration section documents how you perform various one-time tasks after you complete installation of Rancher and start using Rancher.
+The [Configuration]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/configuration/access-control/) section documents how you perform various one-time tasks after you complete installation of Rancher and start using Rancher.
 
 The next three sections--[Using Rancher Through Native Docker CLI]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/native-docker/), [Rancher Compose]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/rancher-compose), and [Rancher UI]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/rancher-ui/applications/stacks/adding-services/)--covers three primary ways you can consume Rancher features.
 


### PR DESCRIPTION
I linked this bit because it reads like it should be a link and is surrounded by other described sections that are linked.

Oddly enough there's not a satisfactory target link to use. The [link provided by the interface](http://docs.rancher.com/rancher/latest/en/concepts/#configuration) opens the left nav to present the potential options, which is precisely what I want, but still presents the user the beginning of the Concepts section on the content pane. That could be confusing is a by product of it re-using the concepts url and not scrolling the page to match the anchor.

So [perhaps there is a /configuration/ endpoint](http://docs.rancher.com/rancher/latest/en/configuration/), but there is not and that only leads to a 404 error.

So I chose to use the first subitem under Configuration, which happens to be the Access Control page. I don't like that if things get re-arranged then it may feel like an arbitrary choice, but it seems less evil to start the reader at a section IN the Configuration section than showing them the Concepts page with different menu items on the left. 

I understand if this ambiguity makes it weird enough not to link, letting people find it on their own.