### PR TITLE
Corrected typo in Internal DNS Service page

### DIFF
--- a/rancher/latest/en/rancher-services/internal-dns-service/index.md
+++ b/rancher/latest/en/rancher-services/internal-dns-service/index.md
@@ -68,7 +68,7 @@ For services that are in different stacks, you can ping the services in a differ
 
 In our example, we have a stack called `stackA`, which contains a service called `foo`, and we also have a stack called `stackB`, which contains a service called `bar`. 
 
-If we exec into one of the containers in the `foo` service, you can ping the `bar` service with `foo.stackB`. 
+If we exec into one of the containers in the `foo` service, you can ping the `bar` service with `bar.stackB`. 
 
 ```bash
 $ ping bar.stackb


### PR DESCRIPTION
Example demonstrates using `bar.stackb` but the actual text described using `foo.stackb`.

The casing changes too (e.g. `stackB`) but if my understanding is correct then DNS is case insensitive so it should not matter. Let me know if I am wrong (or if you would just like me to) and I can correct that in the example too.