### PR TITLE
Clarify keys that can be included when starting services

### DIFF
--- a/os/cloud-config/index.md
+++ b/os/cloud-config/index.md
@@ -113,6 +113,7 @@ rancher:
       image: nginx
       restart: always
 ```  
+Additional keys could also be passed in (i.e. Under restart with same indent) that match usual docker commands. These include ports (-p in docker), net (as per --net flag), command (the command to run on the image), volumes (-v in docker), privileged, etc.
 
 #### System Docker vs. Docker
 


### PR DESCRIPTION
In current docs it wasn't clear to me what keys could be included when starting a service, especially as here it is called ports but that isn't the flag in docker itself.

The changes add some notes on the key flags.