### PR TITLE
kubectl's exec requires upgrade to be Capitalised

### DIFF
--- a/rancher/v1.2/en/installing-rancher/installing-server/basic-ssl-config/index.md
+++ b/rancher/v1.2/en/installing-rancher/installing-server/basic-ssl-config/index.md
@@ -69,7 +69,7 @@ server {
         proxy_pass http://rancher;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection "Upgrade";
         # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
         proxy_read_timeout 900s;
     }


### PR DESCRIPTION
I couldn't get Kubernete's kubectl exec to work with Rancher 1.2.0-pre2 because I had nginx providing ssl termination as per the instructions here. I changed the Connection header to "Upgrade" and kubectl works. Looks like kubectl or whatever library it's using is case-sensitive.