### PR TITLE
Fix typo in rancher-compose docs: servives => services

### DIFF
--- a/rancher/v1.2/en/cattle/rancher-compose/commands/index.md
+++ b/rancher/v1.2/en/cattle/rancher-compose/commands/index.md
@@ -10,7 +10,7 @@ redirect_from:
 ## Command and Options
 ---
 
-The Rancher Compose tool works just like the popular Docker Compose and supports the V1 version of  `docker-compose.yml` files. To enable features that are supported in Rancher, you can also have a `rancher-compose.yml` which extends and overwrites the `docker-compose.yml`. For example, scale of servives and health checks would be in the `rancher-compose.yml` file.
+The Rancher Compose tool works just like the popular Docker Compose and supports the V1 version of  `docker-compose.yml` files. To enable features that are supported in Rancher, you can also have a `rancher-compose.yml` which extends and overwrites the `docker-compose.yml`. For example, scale of services and health checks would be in the `rancher-compose.yml` file.
 
 ### Rancher-Compose Commands
 


### PR DESCRIPTION
Fixes small typo on [rancher-compose commands](http://docs.rancher.com/rancher/v1.2/en/cattle/rancher-compose/commands/) page. Changes "scale of servives" to "scale of services".