### PR TITLE
nginx proxy connection upgrade fix

### DIFF
--- a/rancher/v1.1/en/installing-rancher/installing-server/basic-ssl-config/index.md
+++ b/rancher/v1.1/en/installing-rancher/installing-server/basic-ssl-config/index.md
@@ -53,6 +53,11 @@ upstream rancher {
     server rancher-server:8080;
 }
 
+map $http_upgrade $connection_upgrade {
+    default Upgrade;
+    ''      close;
+}
+
 server {
     listen 443 ssl;
     server_name <server>;
@@ -67,7 +72,7 @@ server {
         proxy_pass http://rancher;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
         proxy_read_timeout 900s;
     }

--- a/rancher/v1.2/en/installing-rancher/installing-server/basic-ssl-config/index.md
+++ b/rancher/v1.2/en/installing-rancher/installing-server/basic-ssl-config/index.md
@@ -54,6 +54,11 @@ upstream rancher {
     server rancher-server:8080;
 }
 
+map $http_upgrade $connection_upgrade {
+    default Upgrade;
+    ''      close;
+}
+
 server {
     listen 443 ssl;
     server_name <server>;
@@ -68,7 +73,7 @@ server {
         proxy_pass http://rancher;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        proxy_set_header Connection $connection_upgrade;
         # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
         proxy_read_timeout 900s;
     }


### PR DESCRIPTION
Setting the Connection header to Upgrade for all requests causes problems creating large kubernetes secrets/configmaps.
Updated the docs to only set the header when required.
