### PR TITLE
Fix moved URL for Docker installation on Ubuntu

### DIFF
--- a/rancher/v1.2/en/quick-start-guide/index.md
+++ b/rancher/v1.2/en/quick-start-guide/index.md
@@ -17,7 +17,7 @@ In this guide, we will create a simple Rancher install, which is a single host i
 
 Provision a Linux host with 64-bit Ubuntu 14.04, which must have a kernel of 3.10+. You can use your laptop, a virtual machine, or a physical server. Please make sure the Linux host has at least **1GB** memory.
 
-To install Docker on the server, follow the instructions from [Docker](https://docs.docker.com/installation/ubuntulinux/).
+To install Docker on the server, follow the instructions from [Docker](https://docs.docker.com/engine/installation/linux/ubuntulinux/).
 
 > **Note:** Currently, Docker for Windows and Docker for Mac are not supported.
 


### PR DESCRIPTION
Was https://docs.docker.com/installation/ubuntulinux/ - changed to https://docs.docker.com/engine/installation/linux/ubuntulinux/