### PR TITLE
HAProxy needs `mode http` not `mode tcp` 

### DIFF
--- a/rancher/v1.2/en/installing-rancher/installing-server/basic-ssl-config/index.md
+++ b/rancher/v1.2/en/installing-rancher/installing-server/basic-ssl-config/index.md
@@ -145,7 +145,7 @@ global
   ssl-server-verify none
 
 defaults
-  mode tcp
+  mode http
   balance roundrobin
   option redispatch
   option forwardfor
@@ -156,7 +156,7 @@ defaults
   timeout server 36000s
 
 frontend http-in
-  mode tcp
+  mode http
   bind *:443 ssl crt /etc/haproxy/certificate.pem
   default_backend rancher_servers
 


### PR DESCRIPTION
Current HAProxy example will not work, and HAProxy will complain with these errors:

    [WARNING] 354/020838 (6) : config : 'option forwardfor' ignored for frontend 'http-in' as it requires HTTP mode.
    [WARNING] 354/020838 (6) : config : 'option forwardfor' ignored for backend 'rancher_servers' as it requires HTTP mode.

Solution, change `mode tcp` to  `mode http`. `mode http` is usually used for HTTP/S traffic, according to https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4