### PR TITLE
Improve typography

### DIFF
--- a/css/rancher-docs.css
+++ b/css/rancher-docs.css
@@ -45,10 +45,12 @@ h3 {
   margin-top: 2rem;
 }
 
-p {
-  font-size: 1.25em;
-  margin-top: 0;
-  line-height: 1.5em;
+@media (min-width: 450px) {
+  p {
+    font-size: 1.25em;
+    margin-top: 0;
+    line-height: 1.5em;
+  }
 }
 
 hr + p {

--- a/css/rancher-docs.css
+++ b/css/rancher-docs.css
@@ -27,13 +27,32 @@ h3, h4, h5, h6 {
   font-weight: 900;
 }
 
-h1, h2 {
+h1 {
   margin-top: 0;
 }
 
+h2 {
+  font-weight: bold;
+  margin-top: 1em;
+  margin-bottom: 0;
+}
+
+h3 {
+  letter-spacing: 0.05em;
+  border-top: 1px solid #ccc;
+  padding-top: 0.25em;
+  margin-bottom: 0.5em;
+  margin-top: 2rem;
+}
+
 p {
+  font-size: 1.25em;
   margin-top: 0;
-  line-height: 1.15em;
+  line-height: 1.5em;
+}
+
+hr + p {
+  margin-top: 1.5rem;
 }
 
 a {


### PR DESCRIPTION
The minimum size on large screens should be around 18px. I also increased the line height since the content is wider than optimal (this can be fixed too).

Other improvements include an adequate contrast for headings and better spacing.

## Before:

![image](https://cloud.githubusercontent.com/assets/2559808/21755080/70b7a680-d5ca-11e6-8575-7123e2adc76b.png)

## Now:

![image](https://cloud.githubusercontent.com/assets/2559808/21755084/83580cf8-d5ca-11e6-9f16-c0da8107747e.png)
