### PR TITLE
Note support matrix in quickstart

### DIFF
--- a/rancher/v1.4/en/quick-start-guide/index.md
+++ b/rancher/v1.4/en/quick-start-guide/index.md
@@ -17,7 +17,9 @@ In this guide, we will create a simple Rancher install, which is a single host i
 
 Provision a Linux host with 64-bit Ubuntu 16.04, which must have a kernel of 3.10+. You can use your laptop, a virtual machine, or a physical server. Please make sure the Linux host has at least **1GB** memory. Install [Docker](https://www.docker.com/) onto the host.
 
-To install Docker on the server, follow the instructions from [Docker](https://docs.docker.com/engine/installation/linux/ubuntulinux/).
+To install Docker on the server first select a compatible version of Docker from the
+[support matrix](http://rancher.com/support-maintenance-terms/), then follow the instructions from
+[Docker](https://docs.docker.com/engine/installation/linux/ubuntulinux/).
 
 > **Note:** Currently, Docker for Windows and Docker for Mac are not supported.
 


### PR DESCRIPTION
Today, following the quick start guide results in running Docker 1.13 which isn't compatible with the current version of Kubernetes. Fix is to reference the support matrix at the right time so people don't go down the wrong path.