### PR TITLE
add SSL headers for haproxy

### DIFF
--- a/rancher/v1.4/en/installing-rancher/installing-server/basic-ssl-config/index.md
+++ b/rancher/v1.4/en/installing-rancher/installing-server/basic-ssl-config/index.md
@@ -156,10 +156,14 @@ defaults
   timeout server 36000s
 
 frontend http-in
-  mode tcp
+  mode http
   bind *:443 ssl crt /etc/haproxy/certificate.pem
   default_backend rancher_servers
 
+  # Set headers for SSL offloading
+  http-request set-header X-Forwarded-Proto https if { ssl_fc }
+  http-request set-header X-Forwarded-Ssl on if { ssl_fc }
+  
   acl is_websocket hdr(Upgrade) -i WebSocket
   acl is_websocket hdr_beg(Host) -i ws
   use_backend rancher_servers if is_websocket


### PR DESCRIPTION
Added headers to HAProxy configuration to tell Rancher that it's behind a proxy that's handling SSL.