### PR TITLE
Make rancher-compose priority clearer

### DIFF
--- a/rancher/v1.5/en/cattle/adding-load-balancers/index.md
+++ b/rancher/v1.5/en/cattle/adding-load-balancers/index.md
@@ -361,7 +361,7 @@ domain.com.* -> hdr_beg(host) -i domain.com.
 
 ##### Priority
 
-By default, Rancher [prioritizes port rules](#default-priority-order) targeting the same service, but if you wanted to, you could customize your own prioritization of the port rules.
+By default, Rancher [prioritizes port rules](#default-priority-order) targeting the same service, but if you wanted to, you could customize your own prioritization of the port rules (lower number is higher priority).
 
 ###### Example `rancher-compose.yml`
 


### PR DESCRIPTION
This took me some time and is nowhere in the documentation. Lower number in the priority field means higher priority in the load balancer.