### PR TITLE
Duplicate entries for  Application Load Balancer section

### DIFF
--- a/rancher/v1.5/en/installing-rancher/installing-server/index.md
+++ b/rancher/v1.5/en/installing-rancher/installing-server/index.md
@@ -226,9 +226,6 @@ We no longer recommend Application Load Balancer (ALB) in AWS over using the Ela
 
 <a id="alb"></a>
 
-### Running Rancher Server Behind an Application Load Balancer (ALB) in AWS
-
-We no longer recommend Application Load Balancer (ALB) in AWS over using the Elastic/Classic Load Balancer (ELB). If you still choose to use an ALB, you will need to direct the traffic to the HTTP port on the nodes, which is `8080` by default.
 
 <a id="ldap"></a>
 

--- a/rancher/v1.5/en/installing-rancher/installing-server/index.md
+++ b/rancher/v1.5/en/installing-rancher/installing-server/index.md
@@ -224,9 +224,6 @@ resource "aws_proxy_protocol_policy" "websockets" {
 
 We no longer recommend Application Load Balancer (ALB) in AWS over using the Elastic/Classic Load Balancer (ELB). If you still choose to use an ALB, you will need to direct the traffic to the HTTP port on the nodes, which is `8080` by default.
 
-<a id="alb"></a>
-
-
 <a id="ldap"></a>
 
 ### Enabling Active Directory or OpenLDAP for TLS


### PR DESCRIPTION
Duplicate entries for Running Rancher Server Behind an Application Load Balancer (ALB) in AWS section so I removed one.