### PR TITLE
SSH User with Rancher AMI

### DIFF
--- a/rancher/v1.5/en/hosts/amazon/index.md
+++ b/rancher/v1.5/en/hosts/amazon/index.md
@@ -44,8 +44,9 @@ Finally, you'll just need to finish filling out the final details of the host(s)
 4. Select the **Root Size** of the image. The default in `docker machine` is 16GB, which is what we have defaulted in Rancher.
 5. (Optional) For the **AMI**, `docker machine` defaults with an Ubuntu 16.04 LTS image in the specific region. You also have the option to select your own AMI. If you input your own AMI, make sure it's available in that region!
 6. (Optional) Provide the **IAM Profile** to be used as an instance profile.
-7. (Optional) Add **[labels]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/hosts/#labels)** to hosts to help organize your hosts and to [schedule services/load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/scheduling/) or to [program external DNS records using an IP other than the host IP]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/external-dns-service/#using-a-specific-ip-for-external-dns).
-8. (Optional) In **Advanced Options**, customize your `docker-machine create` command with [Docker engine options](https://docs.docker.com/machine/reference/create/#specifying-configuration-options-for-the-created-docker-engine).
-9. When complete, click **Create**.
+7. If using the Amazon EC2 machine driver be sure to use the `rancher` user for the ***SSH User*** when using the rancher ami. 
+8. (Optional) Add **[labels]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/hosts/#labels)** to hosts to help organize your hosts and to [schedule services/load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/scheduling/) or to [program external DNS records using an IP other than the host IP]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/external-dns-service/#using-a-specific-ip-for-external-dns).
+9. (Optional) In **Advanced Options**, customize your `docker-machine create` command with [Docker engine options](https://docs.docker.com/machine/reference/create/#specifying-configuration-options-for-the-created-docker-engine).
+10. When complete, click **Create**.
 
 Rancher will create the EC2 instance(s) and launch the _rancher-agent_ container in the instance. In a couple of minutes, the host will be active and available for [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/).


### PR DESCRIPTION
If people using EC2 process to add host, the default ssh user comes up as ubuntu and this fails if you use the rancher ami for the AZ. I'm open to edits for #7.