### PR TITLE
remove backslash from command pipe

### DIFF
--- a/rancher/v1.5/en/hosts/index.md
+++ b/rancher/v1.5/en/hosts/index.md
@@ -27,13 +27,13 @@ Version               | Supported? | Kubernetes Support? | Install Script |
 ----------------------|------------|---------------------|-----------------
 `1.9.x` and earlier   | No         |                     |
 `1.10.0` - `1.10.2`   | No         |                     |
-`1.10.3` (and higher) | **Yes**    | **Yes**             | `curl https://releases.rancher.com/install-docker/1.10.sh \| sh`
-`1.11.x`              | No         |                     | `curl https://releases.rancher.com/install-docker/1.11.sh \| sh`
+`1.10.3` (and higher) | **Yes**    | **Yes**             | `curl https://releases.rancher.com/install-docker/1.10.sh | sh`
+`1.11.x`              | No         |                     | `curl https://releases.rancher.com/install-docker/1.11.sh | sh`
 `1.12.0` - `1.12.2`   | No         |                     |
-`1.12.3` (and higher) | **Yes**    | **Yes**             | `curl https://releases.rancher.com/install-docker/1.12.sh \| sh`
-`1.13.x`              | **Yes**    | No                  | `curl https://releases.rancher.com/install-docker/1.13.sh \| sh`
-`17.03.x-ce`          | **Yes**    | No                  | `curl https://releases.rancher.com/install-docker/17.03.sh \| sh`
-`17.04.x-ce`          | No         |                     | `curl https://releases.rancher.com/install-docker/17.04.sh \| sh`
+`1.12.3` (and higher) | **Yes**    | **Yes**             | `curl https://releases.rancher.com/install-docker/1.12.sh | sh`
+`1.13.x`              | **Yes**    | No                  | `curl https://releases.rancher.com/install-docker/1.13.sh | sh`
+`17.03.x-ce`          | **Yes**    | No                  | `curl https://releases.rancher.com/install-docker/17.03.sh | sh`
+`17.04.x-ce`          | No         |                     | `curl https://releases.rancher.com/install-docker/17.04.sh | sh`
 
 ### Installing a Specific Docker Version
 


### PR DESCRIPTION
All of the Docker installation commands turned `| sh` into `\| sh`. I've removed the backslash.