### PR TITLE
Update index.md

### DIFF
--- a/rancher/v1.5/en/kubernetes/providers/index.md
+++ b/rancher/v1.5/en/kubernetes/providers/index.md
@@ -21,7 +21,7 @@ By default, the orchestration for Kubernetes is set to `rancher`.
 
 ### AWS
 
-  * **Nodes:** Supports only AWS hosts added either as a [custom host]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/hosts/custom/) or [through the Rancher UI]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/hosts/amazon/).
+  * **Nodes:** Supports only AWS hosts added as a [custom host]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/hosts/custom/).
   * **Load Balancers:** Launches an AWS Elastic Load Balancer (ELB) as a Load Balancer service. You can still create Rancher load balancers by using an [ingress]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/kubernetes/ingress/).
   * **Persistent Volumes**: Ability to use AWS Elastic Block Stores (EBS) for [persistent volumes]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/kubernetes/storage/).
 


### PR DESCRIPTION
Clearing up that only hosts added via custom host command work when aws is the k8s provider. Machine driver cant provision correctly because the hostname passed to DM arent resolvable.


https://github.com/rancher/rancher/issues/7455#issuecomment-280092873