### PR TITLE
Reflect x86 architecture requirement

### DIFF
--- a/rancher/v1.6/en/hosts/index.md
+++ b/rancher/v1.6/en/hosts/index.md
@@ -10,6 +10,7 @@ lang: en
 
 Hosts are the most basic unit of resource within Rancher and is represented as any Linux server, virtual or physical, with the following minimum requirements:
 
+* x86 CPU architecture
 * Any modern Linux distribution with a [supported version of Docker](#supported-docker-versions). [RancherOS](http://docs.rancher.com/os/), Ubuntu, RHEL/CentOS 7 are more heavily tested.
   * For RHEL/CentOS, the default storage driver, i.e. devicemapper using loopback, is not recommended by [Docker](https://docs.docker.com/engine/reference/commandline/dockerd/#/storage-driver-options). Please refer to the Docker documentation on how to change it.
   * For RHEL/CentOS, if you want to enable SELinux, you will need to [install an additional SELinux module]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/installing-rancher/selinux/).


### PR DESCRIPTION
Added explanation that a x86 architecture is required to run a Rancher node