### PR TITLE
Fixing 'Multi Container using Rancher CI' example.

### DIFF
--- a/rancher/v1.2/en/quick-start-guide/index.md
+++ b/rancher/v1.2/en/quick-start-guide/index.md
@@ -167,7 +167,7 @@ services:
         path: ''
         priority: 1
         protocol: http
-        service: quickstartguide/web
+        service: web
         source_port: 80
         target_port: 8080
     health_check:


### PR DESCRIPTION
With the `quickstartguide/` bit, I got this error:  `ERRO[0002] Failed to start: letschatapplb : Failed to find stack: quickstartguide`

Without that bit, the example seems to work.