### PR TITLE
Add IAM role requirements for route53 external DNS provider

### DIFF
--- a/rancher/v1.1/en/cattle/external-dns-service/index.md
+++ b/rancher/v1.1/en/cattle/external-dns-service/index.md
@@ -17,6 +17,42 @@ As part of the [Rancher catalog]({{site.baseurl}}/rancher/{{page.version}}/{{pag
 * For every environment in your Rancher setup, there should be a `route53` service of scale 1.
 * Multiple Rancher instances should not share the same `hosted zone`.
 
+### Required AWS IAM permissions
+
+The following IAM policy describes the minimum set of permissions needed for Route53 DNS to work.
+Make sure that the AWS security credentials (Access Key ID / Secret Access Key) that you are specifying have been granted at least these permissions.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetHostedZone",
+                "route53:GetHostedZoneCount",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+```
+
+> **Note:** When using this JSON document to create a custom IAM policy in AWS, replace `<HOSTED_ZONE_ID>` with the ID of the Route53 hosted zone or use a wildcard ('*').
+
 ### Launching Route53 Service
 
 From the **Catalog** tab, you can select the **Route53 DNS Stack**.

--- a/rancher/v1.2/en/cattle/external-dns-service/index.md
+++ b/rancher/v1.2/en/cattle/external-dns-service/index.md
@@ -17,6 +17,42 @@ As part of the [Rancher catalog]({{site.baseurl}}/rancher/{{page.version}}/{{pag
 * For every environment in your Rancher setup, there should be a `route53` service of scale 1.
 * Multiple Rancher instances should not share the same `hosted zone`.
 
+### Required AWS IAM permissions
+
+The following IAM policy describes the minimum set of permissions needed for Route53 DNS to work.
+Make sure that the AWS security credentials (Access Key ID / Secret Access Key) that you are specifying have been granted at least these permissions.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetHostedZone",
+                "route53:GetHostedZoneCount",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+```
+
+> **Note:** When using this JSON document to create a custom IAM policy in AWS, replace `<HOSTED_ZONE_ID>` with the ID of the Route53 hosted zone or use a wildcard ('*').
+
 ### Launching Route53 Service
 
 From the **Catalog** tab, you can select the **Route53 DNS Stack**.

--- a/rancher/v1.3/en/cattle/external-dns-service/index.md
+++ b/rancher/v1.3/en/cattle/external-dns-service/index.md
@@ -17,6 +17,42 @@ As part of the [Rancher catalog]({{site.baseurl}}/rancher/{{page.version}}/{{pag
 * For every environment in your Rancher setup, there should be a `route53` service of scale 1.
 * Multiple Rancher instances should not share the same `hosted zone`.
 
+### Required AWS IAM permissions
+
+The following IAM policy describes the minimum set of permissions needed for Route53 DNS to work.
+Make sure that the AWS security credentials (Access Key ID / Secret Access Key) that you are specifying have been granted at least these permissions.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetHostedZone",
+                "route53:GetHostedZoneCount",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+```
+
+> **Note:** When using this JSON document to create a custom IAM policy in AWS, replace `<HOSTED_ZONE_ID>` with the ID of the Route53 hosted zone or use a wildcard ('*').
+
 ### Launching Route53 Service
 
 From the **Catalog** tab, you can select the **Route53 DNS Stack**.

--- a/rancher/v1.4/en/cattle/external-dns-service/index.md
+++ b/rancher/v1.4/en/cattle/external-dns-service/index.md
@@ -15,6 +15,42 @@ As part of the [Rancher catalog]({{site.baseurl}}/rancher/{{page.version}}/{{pag
 * For every environment in your Rancher setup, there should be a `route53` service of scale 1.
 * Multiple Rancher instances should not share the same `hosted zone`.
 
+### Required AWS IAM permissions
+
+The following IAM policy describes the minimum set of permissions needed for Route53 DNS to work.
+Make sure that the AWS security credentials (Access Key ID / Secret Access Key) that you are specifying have been granted at least these permissions.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetHostedZone",
+                "route53:GetHostedZoneCount",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+```
+
+> **Note:** When using this JSON document to create a custom IAM policy in AWS, replace `<HOSTED_ZONE_ID>` with the ID of the Route53 hosted zone or use a wildcard ('*').
+
 ### Launching Route53 Service
 
 From the **Catalog** tab, you can select the **Route53 DNS Stack**.

--- a/rancher/v1.5/en/cattle/external-dns-service/index.md
+++ b/rancher/v1.5/en/cattle/external-dns-service/index.md
@@ -15,6 +15,42 @@ As part of the [Rancher catalog]({{site.baseurl}}/rancher/{{page.version}}/{{pag
 * For every environment in your Rancher setup, there should be a `route53` service of scale 1.
 * Multiple Rancher instances should not share the same `hosted zone`.
 
+### Required AWS IAM permissions
+
+The following IAM policy describes the minimum set of permissions needed for Route53 DNS to work.
+Make sure that the AWS security credentials (Access Key ID / Secret Access Key) that you are specifying, or the IAM role you associated to the host(s), have been granted at least these permissions.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetHostedZone",
+                "route53:GetHostedZoneCount",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+```
+
+> **Note:** When using this JSON document to create a custom IAM policy in AWS, replace `<HOSTED_ZONE_ID>` with the ID of the Route53 hosted zone or use a wildcard ('*').
+
 ### Launching Route53 Service
 
 From the **Catalog** tab, you can select the **Route53 DNS Stack**.

--- a/rancher/v1.6/en/cattle/external-dns-service/index.md
+++ b/rancher/v1.6/en/cattle/external-dns-service/index.md
@@ -15,6 +15,42 @@ As part of the [Rancher catalog]({{site.baseurl}}/rancher/{{page.version}}/{{pag
 * For every environment in your Rancher setup, there should be a `route53` service of scale 1.
 * Multiple Rancher instances should not share the same `hosted zone`.
 
+### Required AWS IAM permissions
+
+The following IAM policy describes the minimum set of permissions needed for Route53 DNS to work.
+Make sure that the AWS security credentials (Access Key ID / Secret Access Key) that you are specifying, or the IAM role you associated to the host(s), have been granted at least these permissions.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetHostedZone",
+                "route53:GetHostedZoneCount",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+```
+
+> **Note:** When using this JSON document to create a custom IAM policy in AWS, replace `<HOSTED_ZONE_ID>` with the ID of the Route53 hosted zone or use a wildcard ('*').
+
 ### Launching Route53 Service
 
 From the **Catalog** tab, you can select the **Route53 DNS Stack**.


### PR DESCRIPTION
IAM role attached to instances only possible v1.5 and higher

Follow-up on https://github.com/rancher/rancher.github.io/pull/716