### PR TITLE
Fix typo in health-check index.md doc

### DIFF
--- a/rancher/v1.1/en/cattle/health-checks/index.md
+++ b/rancher/v1.1/en/cattle/health-checks/index.md
@@ -44,7 +44,7 @@ Use the following options to configure Health Checks:
 
 ### Adding Health Checks in the UI
 
-For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigatiing to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
+For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigating to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
 
 ### Adding Health Checks to Services in Rancher Compose
 

--- a/rancher/v1.2/en/cattle/health-checks/index.md
+++ b/rancher/v1.2/en/cattle/health-checks/index.md
@@ -44,7 +44,7 @@ Use the following options to configure Health Checks:
 
 ### Adding Health Checks in the UI
 
-For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigatiing to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
+For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigating to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
 
 ### Adding Health Checks to Services in Rancher Compose
 

--- a/rancher/v1.3/en/cattle/health-checks/index.md
+++ b/rancher/v1.3/en/cattle/health-checks/index.md
@@ -44,7 +44,7 @@ Use the following options to configure Health Checks:
 
 ### Adding Health Checks in the UI
 
-For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigatiing to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
+For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigating to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
 
 ### Adding Health Checks to Services in Rancher Compose
 

--- a/rancher/v1.4/en/cattle/health-checks/index.md
+++ b/rancher/v1.4/en/cattle/health-checks/index.md
@@ -42,7 +42,7 @@ Use the following options to configure Health Checks:
 
 ### Adding Health Checks in the UI
 
-For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigatiing to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
+For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigating to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
 
 ### Adding Health Checks to Services in Rancher Compose
 

--- a/rancher/v1.5/en/cattle/health-checks/index.md
+++ b/rancher/v1.5/en/cattle/health-checks/index.md
@@ -42,7 +42,7 @@ Use the following options to configure Health Checks:
 
 ### Adding Health Checks in the UI
 
-For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigatiing to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
+For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigating to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
 
 ### Adding Health Checks to Services in Rancher Compose
 

--- a/rancher/v1.6/en/cattle/health-checks/index.md
+++ b/rancher/v1.6/en/cattle/health-checks/index.md
@@ -42,7 +42,7 @@ Use the following options to configure Health Checks:
 
 ### Adding Health Checks in the UI
 
-For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigatiing to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
+For [services]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-services/) or [load balancers]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/adding-load-balancers/), health checks can be added by navigating to the **Health Check** tab. You can check TCP connections or HTTP responses for services and change the default values for the health check configuration.
 
 ### Adding Health Checks to Services in Rancher Compose
 


### PR DESCRIPTION
Updated `navigatiing` => `navigating` in all the versions
https://github.com/rancher/rancher.github.io/search?utf8=%E2%9C%93&q=navigatiing&type=