### PR TITLE
corrected plural to singular for Environment

### DIFF
--- a/_includes/rancher-sidebar-v1.6.html
+++ b/_includes/rancher-sidebar-v1.6.html
@@ -76,7 +76,7 @@
           <ul>
             <li><a href="{{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/environments/">Managing Environments</a></li>
             <li><a href="{{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/environments/#what-is-an-environment-template">Environment Templates</a></li>
-            <li><a href="{{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/environments/#membership-roles">Roles in an Environments</a></li>
+            <li><a href="{{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/environments/#membership-roles">Roles in an Environment</a></li>
           </ul>
     </li>
     <li>


### PR DESCRIPTION
From 'Roles in an Environments' to 'Roles in an Environment'. 