### PR TITLE
Changed link [sysctl setting] to one that works

### DIFF
--- a/os/v1.0/en/configuration/index.md
+++ b/os/v1.0/en/configuration/index.md
@@ -39,7 +39,7 @@ In our example above, we have our `#cloud-config` line to indicate it's a cloud-
 ### Manually Changing Configuration
 
 To update RancherOS configuration after booting, the `ros config set <key> <value>` command can be used.
-For more complicated settings, like the [sysctl settings]({{page.osbaseurl}}/configuration/sysctl/index.md), you can also create a small YAML file and then run `sudo ros config merge -i <your yaml file>`.
+For more complicated settings, like the [sysctl settings]({{page.osbaseurl}}/configuration/sysctl/), you can also create a small YAML file and then run `sudo ros config merge -i <your yaml file>`.
 
 #### Getting Values
 


### PR DESCRIPTION
This [sysctl setting] link was generating a 404 error. I removed the index.md file from the link. It also appeared that index.html was ok to use, but I went with removing it instead.