### PR TITLE
Update index.md

### DIFF
--- a/rancher/v1.6/en/rancher-services/storage-service/rancher-nfs/index.md
+++ b/rancher/v1.6/en/rancher-services/storage-service/rancher-nfs/index.md
@@ -29,7 +29,7 @@ sudo chown nobody:nogroup /nfs
 Modify the exports file (`/etc/exports`).
 
 ```bash
-/nfs    *(rw,sync,no_subtree_check)
+/nfs    *(rw,sync,no_subtree_check,no_root_squash)
 ```
 
 After all the modifications, restart the NFS kernel server. 


### PR DESCRIPTION
When any service try to use `chown` command in a NFS storage and the NSF server is not mounted with the option `no_root_squash`, it will raised error: 'chown: /var/lib/postgresql/data/pgdata: Operation not permitted'

For example, Postgres service raises this error. With this options this is fixed.