### PR TITLE
Fix documentation pages displaying "403 Forbidden"

### DIFF
--- a/rancher/v1.0/en/installing-rancher/installing-server/no-internet-access/index.md
+++ b/rancher/v1.0/en/installing-rancher/installing-server/no-internet-access/index.md
@@ -1,4 +1,4 @@
-f---
+---
 title: Rancher Server with No Internet Access
 layout: rancher-default-v1.0
 version: v1.0

--- a/rancher/v1.0/en/upgrading/index.md
+++ b/rancher/v1.0/en/upgrading/index.md
@@ -1,4 +1,4 @@
-f---
+---
 title: Upgrading Rancher
 layout: rancher-default-v1.0
 version: v1.0


### PR DESCRIPTION
The following links should be valid, but present "403" error pages.

- http://rancher.com/docs/rancher/v1.0/en/upgrading/
- http://rancher.com/docs/rancher/v1.0/en/installing-rancher/installing-server/no-internet-access/

My suspicion is that the Jekyll YAML front matter has been corrupted with a rogue character, and this is preventing the page from being displayed.

I'm afraid this commit is un-tested, as I've not looked into what is required for verification.
