### PR TITLE
Got rid of smart quotes in the busydash example

### DIFF
--- a/os/v1.1/en/quick-start-guide/index.md
+++ b/os/v1.1/en/quick-start-guide/index.md
@@ -99,7 +99,7 @@ To make the container survive during the reboots, you can create the `/opt/ranch
 
 ```
 $ sudo mkdir -p /opt/rancher/bin
-$ echo “sudo system-docker start busydash” | sudo tee -a /opt/rancher/bin/start.sh
+$ echo "sudo system-docker start busydash" | sudo tee -a /opt/rancher/bin/start.sh
 $ sudo chmod 755 /opt/rancher/bin/start.sh
 ```
 


### PR DESCRIPTION
Smart quotes are evil, and mess up command lines