### PR TITLE
Add reference to the waiting for resources section

### DIFF
--- a/rancher/v1.6/en/cli/commands/index.md
+++ b/rancher/v1.6/en/cli/commands/index.md
@@ -780,6 +780,11 @@ $ rancher inspect <stackName>/<serviceName>
 
 The `rancher wait` command waits for a resource to complete it's action. This is very useful for when automating Rancher commands so that you can add in the script to wait for the resource to be ready for more actions.
 
+This command pairs well with the global options `--wait-timeout` and `--wait-state`, see the [Waiting for Resources](#rancher-waiting-for-resources) section.
+
+
+<br>
+
 ```bash
 $ rancher start 1i1
 $ rancher wait 1i1


### PR DESCRIPTION
I came straight to this entry in the docs and was confused not to find more information about arguments that could be passed to the wait sub-command. Then I saw that it is designed to work with the global options mentioned earlier in the page.