### PR TITLE
advertise-address interface should use host

### DIFF
--- a/rancher/v1.6/en/installing-rancher/installing-server/index.md
+++ b/rancher/v1.6/en/installing-rancher/installing-server/index.md
@@ -173,7 +173,7 @@ Running Rancher server in High Availability (HA) is as easy as running [Rancher 
 | Option | Example | Description |
 |---|---|---|
 | IP address | `--advertise-address 192.168.100.100` | Uses the give IP address |
-| Interface | `--advertise-address eth0` | Retrieves the IP of the given interface |
+| Interface | `--advertise-address eth0` | Retrieves the IP of the given interface (use with --network host) |
 | awslocal | `--advertise-address awslocal` | Retrieves the IP from `http://169.254.169.254/latest/meta-data/local-ipv4` |
 | ipify | `--advertise-address ipify` | Retrieves the IP from `https://api.ipify.org` |
 


### PR DESCRIPTION
I am both making a PR and asking a question? Isn't it implied to use `--network host` when starting rancher with `--advertise-address eth0` (or any other interface for that matter)?

If so, could also add a comment [here](https://github.com/rancher/rancher/blob/v1.6/server/bin/entry#L84)?

I spent quite a large amount of time debugging error messages like this:

```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.hazelcast.core.HazelcastInstance]: Factory method 'Hazelcast' threw exception; nested exception is com.hazelcast.core.HazelcastException: java.net.UnknownHostException: ens192
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:189)
        at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:588)
        ... 107 common frames omitted
Caused by: com.hazelcast.core.HazelcastException: java.net.UnknownHostException: ens192
```

Since it spewed my console with quite large stacktraces, it was hard to see the line saying "UnknownHostException", but seeing entry code made it obvious, its checking the `sys` filesystem in the container, failing which it defaults to thinking its a host address.

```
            if [ -e "/sys/class/net/$1" ]; then
                export CATTLE_CLUSTER_ADVERTISE_ADDRESS=$(ip addr show dev $1 | grep -w inet | awk '{print $2}' | cut -f1 -d/)
            elif [ "$1" = "awslocal" ]; then
                export CATTLE_CLUSTER_ADVERTISE_ADDRESS=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
            elif [ "$1" = "ipify" ]; then
                export CATTLE_CLUSTER_ADVERTISE_ADDRESS=$(curl -s https://api.ipify.org)
            else
                export CATTLE_CLUSTER_ADVERTISE_ADDRESS=$1
            fi
```