### PR TITLE
Use http2 module in Nginx config instead of spdy

### DIFF
--- a/rancher/v1.6/en/installing-rancher/installing-server/basic-ssl-config/index.md
+++ b/rancher/v1.6/en/installing-rancher/installing-server/basic-ssl-config/index.md
@@ -66,7 +66,7 @@ map $http_upgrade $connection_upgrade {
 }
 
 server {
-    listen 443 ssl spdy;
+    listen 443 ssl http2;
     server_name <server>;
     ssl_certificate <cert_file>;
     ssl_certificate_key <key_file>;


### PR DESCRIPTION
To avoid warnings when running Nginx you have to use http2 module instead of spdy.

From official doc http://nginx.org/en/docs/http/ngx_http_spdy_module.html
Module ngx_http_spdy_module: This module was superseded by the ngx_http_v2_module module in 1.9.5.