### PR TITLE
Fix v1.6: Environment scope definition

### DIFF
--- a/rancher/v1.6/en/rancher-services/storage-service/index.md
+++ b/rancher/v1.6/en/rancher-services/storage-service/index.md
@@ -127,7 +127,6 @@ services:
     - bar:/var/lib/storage
 volumes:
   bar:
-    driver: rancher-nfs
     external: true
 ```
 


### PR DESCRIPTION
Setting `external: true`, it's supposed that volume was already created and exists at docker daemon. Docker just tries to look for it by name, driver and driver_opts are implicit, https://docs.docker.com/compose/compose-file/compose-file-v2/#external
`If set to true, specifies that this volume has been created outside of Compose. docker-compose up will not attempt to create it, and will raise an error if it doesn’t exist.`
`external cannot be used in conjunction with other volume configuration keys (driver, driver_opts).`

Removed `driver` defintion.