### PR TITLE
Fix ros config example

### DIFF
--- a/os/v1.1/en/storage/additional-mounts/index.md
+++ b/os/v1.1/en/storage/additional-mounts/index.md
@@ -21,7 +21,7 @@ mounts:
 As you will use the `ros` cli most probably, it would look like this:
 
 ```
-ros config set mounts '[["/dev/vdb","/mnt/s","ext4"]]'
+ros config set mounts '[["/dev/vdb","/mnt/s","ext4", ""]]'
 ```
 
 **hint**: You need to pre-format the disks, rancher-os will not do this for you. The mount will not work (silently) until you formatted the disk, e.g. using:


### PR DESCRIPTION
The docs indicate that the 4th parameter may not be omitted else the server crashes, yet the example shows the mounts being set with the 4th parameter omitted. That seems wrong. :) So, I just added the blank 4th parameter as explained immediately above the example.