### PR TITLE
Note to users about rancher compose + secrets combination

### DIFF
--- a/rancher/v1.6/en/cattle/secrets/index.md
+++ b/rancher/v1.6/en/cattle/secrets/index.md
@@ -112,7 +112,7 @@ When secrets are added to a container, the secrets are written to a tmpfs volume
 
 #### Adding secrets using Rancher CLI
 
-> **Note:** Secrets were introduced in compose file version 3. As Rancher does not support compose version 3, we enabled the use of secrets in version 2. Also building stacks with secrets combination using rancher compose doesn't work. Use Rancher cli for building stacks if you need to use secrets in compose files.
+> **Note:** Secrets were introduced in compose file version 3. As Rancher does not support compose version 3, we enabled the use of secrets in version 2, which can be used with the [Rancher CLI]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cli/), but not the [rancher-compose CLI]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/cattle/rancher-compose/). 
 
 For default usage of secrets, you can reference the secret by name in the secrets array in the `docker-compose.yml`. The target filename will be the same name as the name of the secret. By default, the target filename will be created as User ID and Group ID `0`, and File Mode of `0444`. Setting `external` to `true` in the `secrets` part will make sure it knows the secret has already been created.
 

--- a/rancher/v1.6/en/cattle/secrets/index.md
+++ b/rancher/v1.6/en/cattle/secrets/index.md
@@ -112,7 +112,7 @@ When secrets are added to a container, the secrets are written to a tmpfs volume
 
 #### Adding secrets using Rancher CLI
 
-> **Note:** Secrets were introduced in compose file version 3. As Rancher does not support compose version 3, we enabled the use of secrets in version 2.
+> **Note:** Secrets were introduced in compose file version 3. As Rancher does not support compose version 3, we enabled the use of secrets in version 2. Also building stacks with secrets combination using rancher compose doesn't work. Use Rancher cli for building stacks if you need to use secrets in compose files.
 
 For default usage of secrets, you can reference the secret by name in the secrets array in the `docker-compose.yml`. The target filename will be the same name as the name of the secret. By default, the target filename will be created as User ID and Group ID `0`, and File Mode of `0444`. Setting `external` to `true` in the `secrets` part will make sure it knows the secret has already been created.
 


### PR DESCRIPTION
A note to users mentioning about docker compose + secrets combination wont work for building stacks. need to use rancher cli for this.