### PR TITLE
sysctl link in os/v1.2/en/configuration/index.md fix

### DIFF
--- a/os/v1.2/en/configuration/index.md
+++ b/os/v1.2/en/configuration/index.md
@@ -39,7 +39,7 @@ In our example above, we have our `#cloud-config` line to indicate it's a cloud-
 ### Manually Changing Configuration
 
 To update RancherOS configuration after booting, the `ros config set <key> <value>` command can be used.
-For more complicated settings, like the [sysctl settings]({{page.osbaseurl}}/sysctl/), you can also create a small YAML file and then run `sudo ros config merge -i <your yaml file>`.
+For more complicated settings, like the [sysctl settings]({{page.osbaseurl}}/configuration/sysctl/), you can also create a small YAML file and then run `sudo ros config merge -i <your yaml file>`.
 
 #### Getting Values
 


### PR DESCRIPTION
Link in page:
http://rancher.com/docs/os/v1.2/en/configuration/

for the __sysctl settings__ goes to:
http://rancher.com/docs/os/v1.2/en/sysctl/

which is an http 404

I think it should go to:
http://rancher.com/docs/os/v1.2/en/configuration/sysctl/

I have simply added the __configuration__ missing bit to the index.md link, but I have not tested it. 
