### PR TITLE
cloud-config link in os/v1.2/en/configuration/hostname/index.md fix

### DIFF
--- a/os/v1.2/en/configuration/hostname/index.md
+++ b/os/v1.2/en/configuration/hostname/index.md
@@ -7,7 +7,7 @@ title: Setting the Hostname in RancherOS
 ## Setting the Hostname
 ---
 
-You can set the hostname of the host using [cloud-config]({baseurl}}/configuration/#cloud-config). The example below shows how to configure it.
+You can set the hostname of the host using [cloud-config]({{page.osbaseurl}}/configuration/#cloud-config). The example below shows how to configure it.
 
 ```yaml
 #cloud-config


### PR DESCRIPTION
Looks like the link in:
http://rancher.com/docs/os/v1.2/en/configuration/hostname/
for the cloud-config info points to:
http://rancher.com/docs/os/v1.2/en/configuration/hostname/%7Bbaseurl%7D%7D/configuration/#cloud-config
and not:
http://rancher.com/docs/os/v1.2/en/configuration/#cloud-config

Changed as per below

