### PR TITLE
If editing latest, replace with page version

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
 </div>
 
 <div class="row wrap">
-<a class="btn btn-primary pull-right" href="https://github.com/rancher/rancher.github.io/tree/master/{{page.path }}">Edit this page <i class="fa fa-pencil"></i></a>
+<a class="btn btn-primary pull-right" href="https://github.com/rancher/rancher.github.io/tree/master/{{page.path.replace("/latest/", "/" + page.version + "/") }}">Edit this page <i class="fa fa-pencil"></i></a>
 </div>
 
 <footer class="clearfix">


### PR DESCRIPTION
I noticed if you try to edit any of the pages labelled `latest` the link to github will break.

This is because github doesn't process the system link correctly.

I haven't had a chance to test this but my intention is just to switch `latest` with the version to fix the link.

I also found a bug on the front page of Rancher.com, I don't see anywhere to report a bug and the code isn't part of the repo.