### PR TITLE
WIP - Initial suggestion of content

### DIFF
--- a/rancher/v1.6/en/cattle/adding-load-balancers/index.md
+++ b/rancher/v1.6/en/cattle/adding-load-balancers/index.md
@@ -97,6 +97,8 @@ Now, let's see the load balancer in action. In the stack view, there is a link t
 
 ### Load Balancer Options in the UI
 
+> **Note:** When using the Load Balancer, any public ports on the targetted conainer/service will need to be removed and target the service's default port
+
 Rancher provides a load balancer running HAProxy software inside the container to direct traffic to the target services.
 
 > **Note:** Load balancers will only work for services that are using the managed network. If you select any other network choice for your target services, it will **not** work with the load balancer.


### PR DESCRIPTION
I've just learnt that when using the Load Balancer, any public ports on the targetted conainer/service will need to be removed and target the service's default port other wise you will get an error with port conflicts.

Addmittedly, my knowledge is very limitted at the moment so this could be a pointless edit to the docs.

If this is something that is considered usefull, I will need to add to older versions.