### PR TITLE
Format Loading-kernel-modules to 1.x

### DIFF
--- a/os/v1.x/en/configuration/loading-kernel-modules/index.md
+++ b/os/v1.x/en/configuration/loading-kernel-modules/index.md
@@ -4,19 +4,21 @@ title: Extra Kernel Modules for RancherOS
 
 ---
 
+## Loading kernel modules
+---
+
 Since RancherOS v0.8, we build our own kernels using an unmodified kernel.org LTS kernel.
 We also build almost all optional extras as modules - so most in-tree modules are available
 in the `kernel-extras` service.
 
+If you do need to build kernel modules for RancherOS, there are 4 options:
 
-If you do need to build kernel modules for RancherOS, there are 3 options:
+* Try the `kernel-extras` service
+* Ask us to add it into the next release
+* If its out of tree, copy the methods used for the zfs and open-iscsi services
+* Build it yourself.
 
-0 Try the `kernel-extras` service
-1 Ask us to add it into the next release
-2 If its out of tree, copy the methods used for the zfs and open-iscsi services
-3 Build it yourself.
-
-## Try the kernel-extras service
+### Try the kernel-extras service
 
 We build the RancherOS kernel with most of the optional drivers as kernel modules, packaged
 into an optional RancherOS service.
@@ -30,13 +32,13 @@ sudo ros service up kernel-extras
 
 The modules should now be available for you to `modprobe`
 
-## Ask us to do it
+### Ask us to do it
 
 Open a GitHub issue in the https://github.com/rancher/os repository - we'll probably add
 it to the kernel-extras next time we build a kernel. Tell us if you need the module at initial
 configuration or boot, and we can add it to the default kernel modules.
 
-## Copy the out of tree build method
+### Copy the out of tree build method
 
 See https://github.com/rancher/os-services/blob/master/z/zfs.yml and 
 https://github.com/rancher/os-services/tree/master/images/20-zfs
@@ -45,7 +47,7 @@ The build container and build.sh script build the source, and then create a tool
 "wonka.sh" import those tools into the console container using `docker run`
 
 
-## Build your own.
+### Build your own.
 
 As an example I'm going build the `intel-ishtp` hid driver using the `rancher/os-zfs:<version>` images to build in, as they should contain the right tools versions for that kernel.
   


### PR DESCRIPTION
I realized that I need to modify the page under 1.x.

Relate to: https://github.com/rancher/rancher.github.io/pull/1021