### PR TITLE
Remove reference to max_packet_size

### DIFF
--- a/rancher/v1.6/en/installing-rancher/installing-server/index.md
+++ b/rancher/v1.6/en/installing-rancher/installing-server/index.md
@@ -35,7 +35,7 @@ Rancher is deployed as a set of Docker containers. Running Rancher is as simple 
     * Option 1: Run with Antelope with default of `COMPACT`
     * Option 2: Run MySQL 5.7 with Barracuda where the default `ROW_FORMAT` is `Dynamic`
   * Recommended settings:
-    * `max_packet_size` >= 32M
+    * `max_allowed_packet` >= 32M (default is usually 16M)
     * `innodb_log_file_size` >= 256M (If you have an existing DB, please make sure to appropriate plan how to change this setting.)
     * `innodb_file_per_table=1`
     * `innodb_buffer_pool_size` >= 1GB (For larger installs, 4-8G pools on dedicated MySQL servers) 


### PR DESCRIPTION
Replace with reference to the presumably-correct configuration setting (as of MySQL 5.7) that the document refers to.