### PR TITLE
Remove double dollar sign in service and stack macro

### DIFF
--- a/rancher/v1.5/en/cattle/scheduling/index.md
+++ b/rancher/v1.5/en/cattle/scheduling/index.md
@@ -194,7 +194,7 @@ When Rancher Compose starts containers for a service, it also automatically crea
 Label | Value
 ----|-----
 io.rancher.stack.name | `$${stack_name}`
-io.rancher.stack_service.name | `$${stack_name}/$${service_name}`
+io.rancher.stack_service.name | `${stack_name}/${service_name}`
 
 <br>
 
@@ -236,14 +236,14 @@ A typical scheduling policy may be to try to spread the containers of a service 
 
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 Since this is a hard anti-affinity rule, we may run into problems if the scale is larger than the number of hosts available.  In this case, we might want to use a soft anti-affinity rule so that the scheduler is still allowed to deploy a container to a host that already has that container running.  Basically, this is a soft rule so it can be ignored if no better alternative exists.
 
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 #### Example 2:
@@ -252,7 +252,7 @@ Another example may be to deploy all the containers on the same host regardless 
 
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_soft: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_soft: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 If a hard affinity rule to itself was chosen instead, the deployment of the first container would fail since there would be no host that currently has that service running.

--- a/rancher/v1.6/en/cattle/scheduling/index.md
+++ b/rancher/v1.6/en/cattle/scheduling/index.md
@@ -197,7 +197,7 @@ When Rancher Compose starts containers for a service, it also automatically crea
 Label | Value
 ----|-----
 io.rancher.stack.name | `$${stack_name}`
-io.rancher.stack_service.name | `$${stack_name}/$${service_name}`
+io.rancher.stack_service.name | `${stack_name}/${service_name}`
 
 <br>
 
@@ -239,14 +239,14 @@ A typical scheduling policy may be to try to spread the containers of a service 
 
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 Since this is a hard anti-affinity rule, we may run into problems if the scale is larger than the number of hosts available.  In this case, we might want to use a soft anti-affinity rule so that the scheduler is still allowed to deploy a container to a host that already has that container running.  Basically, this is a soft rule so it can be ignored if no better alternative exists.
 
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 #### Example 2:
@@ -255,7 +255,7 @@ Another example may be to deploy all the containers on the same host regardless 
 
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_soft: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_soft: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 If a hard affinity rule to itself was chosen instead, the deployment of the first container would fail since there would be no host that currently has that service running.

--- a/rancher/v1.6/zh/cattle/scheduling/index.md
+++ b/rancher/v1.6/zh/cattle/scheduling/index.md
@@ -199,7 +199,7 @@ labels:
 标签 | 值
 ----|-----
 io.rancher.stack.name | `$${stack_name}`
-io.rancher.stack_service.name | `$${stack_name}/$${service_name}`
+io.rancher.stack_service.name | `${stack_name}/${service_name}`
 
 <br>
 
@@ -241,13 +241,13 @@ labels:
 
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 由于这是一个很强的反相关性规则，如果比例大于可用主机数量，我们可能会遇到问题。 在这种情况下，我们可能需要使用软反相关性规则，以便调度程序仍然允许将容器部署到已经具有该容器的主机。 基本上，这是一个软规则，所以如果没有更好的选择存在，它可以被忽略。
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 #### 示例2:
@@ -256,7 +256,7 @@ labels:
 
 ```yaml
 labels:
-  io.rancher.scheduler.affinity:container_label_soft: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  io.rancher.scheduler.affinity:container_label_soft: io.rancher.stack_service.name=${stack_name}/${service_name}
 ```
 
 如果选择了自己的硬约束规则，则第一个容器的部署将失败，因为目前没有运行该服务的主机。


### PR DESCRIPTION
According to [macro definitions in code](https://github.com/rancher/cattle/blob/master/modules/caas/backend/src/main/java/io/cattle/platform/allocator/service/AllocationHelperImpl.java#L40)
correct values are `${service_name}` and `${stack_name}`