### PR TITLE
Use partprobe vs reboot

### DIFF
--- a/os/v1.2/en/running-rancheros/server/raspberry-pi/index.md
+++ b/os/v1.2/en/running-rancheros/server/raspberry-pi/index.md
@@ -22,7 +22,7 @@ RancherOS does not currently expand the root partition to fill the remainder of 
 2. Create a `n`ew partition
 3. Press `[Enter]` four (4x) times to accept the defaults
 4. Then `w`rite the table and exit
-5. `sudo reboot` to reboot and reload the new partition table
+5. `sudo partprobe /dev/mmcblk0` to reload the new partition table
 6. `sudo mkdir /mnt/docker` to create the directory to be used as the new Docker root
 7. `sudo ros config set rancher.docker.extra_args [-g,/mnt/docker]` to configure Docker to use the new root
 8. `sudo mkfs.ext4 /dev/mmcblk0p3` to format the disk


### PR DESCRIPTION
Partprobe is less disruptive than a reboot, and functions all the same.

I ended up doing this (as well as switching fdisk for a scriptable sfdisk) to automate expanding my raspberry pi.  In case it's useful, the ansible command looked like this:

``` yaml
  tasks:
    - name: 'build remainder of partition table'
      raw: "sudo sfdisk -d /dev/mmcblk0 > disklayout && echo \";\" >> disklayout && cat disklayout && sudo sfdisk --no-reread /dev/mmcblk0 < disklayout && sudo partprobe /dev/mmcblk0 && sudo mkdir /mnt/docker && sudo ros config set rancher.docker.extra_args [-g,/mnt/docker] && sudo mkfs.ext4 /dev/mmcblk0p3 && sudo ros config set mounts \"[['/dev/mmcblk0p3','/mnt/docker','ext4','']]\" && sudo mount /dev/mmcblk0p3 /mnt/docker && sudo system-docker restart docker"
```