### PR TITLE
Fix autologin typo

### DIFF
--- a/os/v1.1/en/configuration/adding-kernel-parameters/index.md
+++ b/os/v1.1/en/configuration/adding-kernel-parameters/index.md
@@ -21,7 +21,7 @@ To edit the kernel boot parameters of an already installed RancherOS system, use
 If you want to set the extra kernel parameters when you are [Installing RancherOS to Disk]({{page.osbaseurl}}/running-rancheros/server/install-to-disk/) please use the `--append` parameter.
 
 ```bash
-$ sudo ros install -d /dev/sda --append "rancheros.autologin=tty1"
+$ sudo ros install -d /dev/sda --append "rancher.autologin=tty1"
 ```
 
 ### Graphical boot screen


### PR DESCRIPTION
The kernel argument is rancher.autologin not rancheros.autologin.