### PR TITLE
Add canonical link to header

### DIFF
--- a/_includes/os-header.html
+++ b/_includes/os-header.html
@@ -12,6 +12,8 @@
       <link href="{{site.baseurl}}/one-point-x/css/lacsso.css?t={{site.time}}" rel="stylesheet">
       <link href="{{site.baseurl}}/one-point-x/css/slicknav.css?t={{site.time}}" rel="stylesheet">
       <link href="{{site.baseurl}}/one-point-x/css/rancher-docs.css?t={{site.time}}" rel="stylesheet">
+
+      <link rel="canonical" href="{{site.URL}}{{site.baseurl}}{{page.url}}"/>
     </head>
     <body class="bg-default" class="bg-default">
         <div class="row body">


### PR DESCRIPTION
Per feedback from the web team, the lack of a canonical link is affecting the site's SEO score. This PR adds it to the template.