### PR TITLE
Add Twitter card to header

### DIFF
--- a/_includes/os-header.html
+++ b/_includes/os-header.html
@@ -14,6 +14,13 @@
       <link href="{{site.baseurl}}/one-point-x/css/rancher-docs.css?t={{site.time}}" rel="stylesheet">
 
       <link rel="canonical" href="{{site.URL}}{{site.baseurl}}{{page.url}}"/>
+
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:description" content="{{page.excerpt}}" />
+      <meta name="twitter:title" content="{{page.title}}" />
+      <meta name="twitter:site" content="@Rancher_Labs" />
+      <meta name="twitter:image" content="https://raw.githubusercontent.com/rancher/docs/master/static/docs/rancher-logo.svg" />
+
     </head>
     <body class="bg-default" class="bg-default">
         <div class="row body">


### PR DESCRIPTION
Per feedback from the web team, the site's SEO score needs to be improved. The lack of a Twitter card is affecting the score.