### PR TITLE
Add Open Graph tags to header

### DIFF
--- a/_includes/os-header.html
+++ b/_includes/os-header.html
@@ -21,6 +21,10 @@
       <meta name="twitter:site" content="@Rancher_Labs" />
       <meta name="twitter:image" content="https://raw.githubusercontent.com/rancher/docs/master/static/docs/rancher-logo.svg" />
 
+      <meta property="og:title" content="{{page.title}}" />
+      <meta property="og:description" content="{{page.excerpt}}" />
+      <meta property="og:url" content="{{site.URL}}{{site.baseurl}}{{page.url}}" />
+      <meta property="og:image" content="https://raw.githubusercontent.com/rancher/docs/master/static/docs/rancher-logo.svg" />
     </head>
     <body class="bg-default" class="bg-default">
         <div class="row body">


### PR DESCRIPTION
Per feedback from the web team, the site's SEO score needs to be improved. The lack of Open Graph meta tags is affecting the score.