### PR TITLE
Test adding chown - builds have failed since #1080

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -13,4 +13,4 @@ RUN mkdir -p os/latest/en \
     && cp -r os/v1.0/en/* os/latest/ \
     && cp -r os/v1.0/en/* os/
 
-RUN jekyll build
+RUN chown -R jekyll:jekyll /build && jekyll build


### PR DESCRIPTION
Builds have been failed on `Step 10/14 : RUN jekyll build` since PR #1080. From the [build logs](https://drone-publish.rancher.io/rancher/rancher.github.io/16/1/3) the error is

> There was an error while trying to write to `/build/Gemfile.lock`. It is likely that you need to grant write permissions for that path. The command '/bin/sh -c jekyll build' returned a non-zero code: 23 time="2020-01-30T22:00:29Z" level=fatal msg="exit status 23"